### PR TITLE
Fix cursor visibility

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -108,7 +108,7 @@ impl Interface<'_> {
             }
             self.device.queue(cursor::Show)?;
         }
-        
+
         self.device.flush()?;
         self.device.disable_raw_mode()?;
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -100,12 +100,16 @@ impl Interface<'_> {
     /// ```
     pub fn exit(mut self) -> Result<()> {
         if !self.relative {
+            self.device.queue(cursor::Show)?;
             self.device.queue(terminal::LeaveAlternateScreen)?;
-            self.device.flush()?;
-        } else if let Some(last_position) = self.current.get_last_position() {
-            self.move_cursor_to(pos!(0, last_position.y()))?;
+        } else {
+            if let Some(last_position) = self.current.get_last_position() {
+                self.move_cursor_to(pos!(0, last_position.y()))?;
+            }
+            self.device.queue(cursor::Show)?;
         }
-
+        
+        self.device.flush()?;
         self.device.disable_raw_mode()?;
 
         println!();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -139,3 +139,39 @@ fn clearing_rest_of_interface() {
 
     assert_eq!("ABC\nD  \n   ", &device.parser().screen().contents());
 }
+
+#[test]
+fn cursor_visible_after_exit_alternate() {
+    let mut device = VirtualDevice::new();
+    let interface = Interface::new_alternate(&mut device).unwrap();
+
+    interface.exit().unwrap();
+
+    let is_visible = !device.parser().screen().hide_cursor();
+    assert!(is_visible);
+}
+
+#[test]
+fn cursor_visible_after_exit_relative() {
+    let mut device = VirtualDevice::new();
+    let interface = Interface::new_relative(&mut device).unwrap();
+
+    interface.exit().unwrap();
+
+    let is_visible = !device.parser().screen().hide_cursor();
+    assert!(is_visible);
+}
+
+#[test]
+fn cursor_visible_after_exit_with_content() {
+    let mut device = VirtualDevice::new();
+    let mut interface = Interface::new_alternate(&mut device).unwrap();
+
+    interface.set(pos!(0, 0), "Hello, world!");
+    interface.apply().unwrap();
+
+    interface.exit().unwrap();
+
+    let is_visible = !device.parser().screen().hide_cursor();
+    assert!(is_visible);
+}


### PR DESCRIPTION
The cursor's visibility wasn't always being restored when exiting an interface. This adds coverage for that scenario and fixes the issue.