### PR TITLE
Convert error type to `ThisError`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ crossterm = "0.29.0"
 unicode-segmentation = "1.12.0"
 unicode-width = "0.2.1"
 vt100 = "0.16.2"
+thiserror = "2.0.16"
 
 [dev-dependencies]
 rand = "0.9.2"

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,15 +1,11 @@
+use thiserror::Error as ThisError;
+
 /// An interface operation's result containing either a successful value or error.
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// A failed interface operation's error information.
-#[derive(Debug)]
+#[derive(ThisError, Debug)]
 pub enum Error {
-    /// A low-level terminal interaction error.
-    Terminal(std::io::Error),
-}
-
-impl From<std::io::Error> for Error {
-    fn from(err: std::io::Error) -> Self {
-        Error::Terminal(err)
-    }
+    #[error("terminal interaction error")]
+    TerminalError(#[from] std::io::Error),
 }


### PR DESCRIPTION
Makes the error type compliant.